### PR TITLE
Update .gitignore and modify package.json scripts for Storybook integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist-ssr
 secrets/**
 
 *storybook.log
+storybook-static

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "@decentralized-credit:registry": "https://npm.pkg.github.com"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "storybook dev -p 6006",
     "build:types": "tsc -p tsconfig.build.json",
     "build": "tsc -b && pnpm build:types && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier --write .",
-    "prepare": "husky",
+    "prepare": "[ -n \"$CI\" ] || husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
This: `"[ -n \"$CI\" ] || husky"` prevents husky from running in a CI environment